### PR TITLE
RISC-V tests: branching (two args) tests where one arg is X0

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -343,6 +343,28 @@ test_ ## testnum: \
     bne x0, TESTNUM, fail; \
 3:
 
+#define TEST_BR2_OP_TAKEN_X0_LHS(testnum, inst, val2 ) \
+test_ ## testnum: \
+    li  TESTNUM, testnum; \
+    li  x2, val2; \
+    inst x0, x2, 2f; \
+    bne x0, TESTNUM, fail; \
+1:  bne x0, TESTNUM, 3f; \
+2:  inst x0, x2, 1b; \
+    bne x0, TESTNUM, fail; \
+3:
+
+#define TEST_BR2_OP_TAKEN_X0_RHS(testnum, inst, val1 ) \
+test_ ## testnum: \
+    li  TESTNUM, testnum; \
+    li  x1, val1; \
+    inst x1, x0, 2f; \
+    bne x0, TESTNUM, fail; \
+1:  bne x0, TESTNUM, 3f; \
+2:  inst x1, x0, 1b; \
+    bne x0, TESTNUM, fail; \
+3:
+
 #define TEST_BR2_OP_NOTTAKEN( testnum, inst, val1, val2 ) \
 test_ ## testnum: \
     li  TESTNUM, testnum; \
@@ -352,6 +374,26 @@ test_ ## testnum: \
     bne x0, TESTNUM, 2f; \
 1:  bne x0, TESTNUM, fail; \
 2:  inst x1, x2, 1b; \
+3:
+
+#define TEST_BR2_OP_NOTTAKEN_X0_LHS( testnum, inst, val2 ) \
+test_ ## testnum: \
+    li  TESTNUM, testnum; \
+    li  x2, val2; \
+    inst x0, x2, 1f; \
+    bne x0, TESTNUM, 2f; \
+1:  bne x0, TESTNUM, fail; \
+2:  inst x0, x2, 1b; \
+3:
+
+#define TEST_BR2_OP_NOTTAKEN_X0_RHS( testnum, inst, val1 ) \
+test_ ## testnum: \
+    li  TESTNUM, testnum; \
+    li  x1, val1; \
+    inst x1, x0, 1f; \
+    bne x0, TESTNUM, 2f; \
+1:  bne x0, TESTNUM, fail; \
+2:  inst x1, x0, 1b; \
 3:
 
 #define TEST_BR2_SRC12_BYPASS( testnum, src1_nops, src2_nops, inst, val1, val2 ) \

--- a/isa/rv64ui/bge.S
+++ b/isa/rv64ui/bge.S
@@ -64,6 +64,30 @@ RVTEST_CODE_BEGIN
     addi x1, x1, 1; \
   )
 
+  #---------------------------
+  # Branching tests against x0
+  #---------------------------
+
+  TEST_BR2_OP_TAKEN_X0_LHS( 25, bge, -1 );
+  TEST_BR2_OP_TAKEN_X0_LHS( 26, bge, 0 );
+  TEST_BR2_OP_TAKEN_X0_RHS( 27, bge, 0 );
+  TEST_BR2_OP_TAKEN_X0_RHS( 28, bge, 1 );
+
+  TEST_BR2_OP_NOTTAKEN_X0_LHS ( 29, bge, 1 ); 
+  TEST_BR2_OP_NOTTAKEN_X0_RHS ( 30, bge, -1 ); 
+
+  # Test same registers should always branch
+
+  TEST_CASE( 31, x1, 1, \
+    li  x1, 1; \
+    bge x0, x0, 2f; \
+    addi x1, x1, 1; \
+1:  bge x1, x1, 3f; \
+2:  bge x2, x2, 1b; \
+    addi x1, x1, 1; \
+3:
+  )
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END

--- a/isa/rv64ui/bgeu.S
+++ b/isa/rv64ui/bgeu.S
@@ -64,6 +64,30 @@ RVTEST_CODE_BEGIN
     addi x1, x1, 1; \
   )
 
+  #---------------------------
+  # Branching tests against x0
+  #---------------------------
+
+  TEST_BR2_OP_TAKEN_X0_LHS( 25, bgeu,  0 );
+  TEST_BR2_OP_TAKEN_X0_RHS( 26, bgeu,  0 );
+  TEST_BR2_OP_TAKEN_X0_RHS( 27, bgeu,  1 );
+  TEST_BR2_OP_TAKEN_X0_RHS( 28, bgeu, -1 ); 
+
+  TEST_BR2_OP_NOTTAKEN_X0_LHS( 29, bgeu, -1 );
+  TEST_BR2_OP_NOTTAKEN_X0_LHS( 30, bgeu,  1 ); 
+
+  # Test same registers should always branch
+
+  TEST_CASE( 31, x1, 1, \
+    li  x1, 1; \
+    bgeu x0, x0, 2f; \
+    addi x1, x1, 1; \
+1:  bgeu x1, x1, 3f; \
+2:  bgeu x2, x2, 1b; \
+    addi x1, x1, 1; \
+3:
+  )
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END

--- a/isa/rv64ui/blt.S
+++ b/isa/rv64ui/blt.S
@@ -61,6 +61,28 @@ RVTEST_CODE_BEGIN
     addi x1, x1, 1; \
   )
 
+  #---------------------------
+  # Branching tests against x0
+  #---------------------------
+
+  TEST_BR2_OP_TAKEN_X0_LHS( 22, blt, 1 );
+  TEST_BR2_OP_TAKEN_X0_RHS( 23, blt, -1 );
+
+  TEST_BR2_OP_NOTTAKEN_X0_LHS ( 24, blt, -1 ); 
+  TEST_BR2_OP_NOTTAKEN_X0_LHS( 25, blt, 0 );
+  TEST_BR2_OP_NOTTAKEN_X0_RHS( 26, blt, 0 );
+  TEST_BR2_OP_NOTTAKEN_X0_RHS ( 27, blt, 1 ); 
+
+  # Test same registers should never branch
+
+  TEST_CASE( 28, x1, 2, \
+    li  x1, 1; \
+    blt x0, x0, fail; \
+    blt x1, x1, fail; \
+    blt x2, x2, fail; \
+1:  addi x1, x1, 1; \
+  )
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END

--- a/isa/rv64ui/bltu.S
+++ b/isa/rv64ui/bltu.S
@@ -61,6 +61,28 @@ RVTEST_CODE_BEGIN
     addi x1, x1, 1; \
   )
 
+  #---------------------------
+  # Branching tests against x0
+  #---------------------------
+
+  TEST_BR2_OP_TAKEN_X0_LHS( 22, bltu,  1 );
+  TEST_BR2_OP_TAKEN_X0_LHS( 23, bltu, -1 ); 
+
+  TEST_BR2_OP_NOTTAKEN_X0_LHS( 24, bltu,  0 );
+  TEST_BR2_OP_NOTTAKEN_X0_RHS( 25, bltu, -1 );
+  TEST_BR2_OP_NOTTAKEN_X0_RHS( 26, bltu,  0 );
+  TEST_BR2_OP_NOTTAKEN_X0_RHS( 27, bltu,  1 ); 
+
+  # Test same registers should never branch
+
+  TEST_CASE( 28, x1, 2, \
+    li  x1, 1; \
+    bltu x0, x0, fail; \
+    bltu x1, x1, fail; \
+    bltu x2, x2, fail; \
+1:  addi x1, x1, 1; \
+  )
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END


### PR DESCRIPTION
Open to allow easy inspecting of diff, for purposes of updating the test suite for the riscv-sandbox.